### PR TITLE
Update install.sh to point to new key.gpg location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,7 +221,7 @@ conf() {
     authKeyFileName="vxinstallerkey.gpg"
 
     # Authentication key URL
-    authKeyURL="https://www.payload-security.com/download.php?file=$authKeyFileName"
+    authKeyURL="https://www.crowdstrike.com/wp-content/sandbox/$authKeyFileName"
 
     # Correct authentication key type
     correctFileType="$(echo -e "application/octet-stream" | tr -d '[[:space:]]')"


### PR DESCRIPTION
https://jira.cs.sys/browse/SANDBOX-476

vxinstallerkey.gpg is being hosted at a different location. PR to update location to https://www.crowdstrike.com/wp-content/sandbox/ from https://www.payload-security.com/download.php?file=

Tested functional on my on-premise environment:

![Screen Shot 2019-04-15 at 11 25 10 PM](https://user-images.githubusercontent.com/49211149/56231859-4bee8700-6034-11e9-883b-4526f2281a9e.png)
